### PR TITLE
Fix exclusion path bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ fn format_gitignore(raw_body: &String, prefix_path: Option<&Path>, language: &st
                 body.push_str(
                     path.join(Path::new(&corrected_line))
                         .to_str()
-                        .expect("Unknown path found in gitignore."),
+                        .expect("Bad path found in gitignore."),
                 );
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,16 +87,29 @@ fn format_gitignore(raw_body: &String, prefix_path: Option<&Path>, language: &st
             // if the next character is a hash
             let first_non_whitespace_char =
                 line.chars().skip_while(|c| c.is_ascii_whitespace()).next();
+
             if first_non_whitespace_char == Some('#') || first_non_whitespace_char == None {
+                // If the line is a comment or blank then add it to the file untouched
                 body.push_str(line);
             } else {
+                // Trim the '!' off the input line (if it exists) and add it to the start of the
+                // output line
+                let trimmed_line = if first_non_whitespace_char == Some('!') {
+                    // The line is an exclusion, so remove the '!' from the start of the path and
+                    // add it to the output string
+                    body.push('!');
+                    &line[1..]
+                } else {
+                    line
+                };
+
                 // A lot of gitignores seem to have erroneous '/'s at the start of their paths, but
                 // rust is not magic so it can't figure out which ones are actually correct so this
                 // will just remove them all
-                let corrected_line = if line.chars().next() == Some('/') {
-                    line.chars().skip(1).collect::<String>()
+                let corrected_line = if trimmed_line.chars().next() == Some('/') {
+                    trimmed_line.chars().skip(1).collect::<String>()
                 } else {
-                    line.to_string()
+                    trimmed_line.to_string()
                 };
 
                 body.push_str(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub fn generate_gitignore_file(languages: Vec<&str>, file_map: &HashMap<String, 
 
     // generate gitignore for each language and append to output string
     for path_and_language in languages.iter() {
-        // Split the path and language, with path being None if the language name doesn't contain a 
+        // Split the path and language, with path being None if the language name doesn't contain a
         // '/'
         let last_slash_index = path_and_language.rfind('/');
         let language = &path_and_language[last_slash_index.map_or(0, |x| x + 1)..];
@@ -217,7 +217,11 @@ pub fn write_to_file(dest: &str, gitignore: String) -> std::io::Result<()> {
     let filepath: PathBuf = Path::new(dest).join(".gitignore");
     println!(
         "Writing file to {}... ✏️ ",
-        filepath.to_str().expect("Unknown output file name.").bright_blue().bold()
+        filepath
+            .to_str()
+            .expect("Unknown output file name.")
+            .bright_blue()
+            .bold()
     );
     let mut file = File::create(filepath)?;
     file.write_all(gitignore.as_bytes())?;
@@ -239,7 +243,11 @@ pub fn append_to_file(destination: &str, gitignore: String) -> std::io::Result<(
     if !combined.is_empty() {
         println!(
             "Loaded existing gitignore file from {} 💾",
-            filepath.to_str().expect("Unknown file path.").bright_blue().bold()
+            filepath
+                .to_str()
+                .expect("Unknown file path.")
+                .bright_blue()
+                .bold()
         );
 
         // write it to file


### PR DESCRIPTION
This fixes a bug that I accidentally added whereby if you added a prefix path to the front of a `.gitignore` template that contained excluded paths (lines beginning with `!`), they would incorrectly have the prefix paths appended **before** the `!`.  Now, the prefix path is appended **after** the `!` thus preserving the meaning of the line.

### Example
#### Command:
```bash
blindfold --lang fl/flutter
```

#### Old Output:
```gitignore
...

# Exceptions to above rules.
fl/!**/ios/**/default.mode1v3
fl/!**/ios/**/default.mode2v3
fl/!**/ios/**/default.pbxuser
fl/!**/ios/**/default.perspectivev3
fl/!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
```

#### New Output:
```gitignore
...

# Exceptions to above rules.
!fl/**/ios/**/default.mode1v3
!fl/**/ios/**/default.mode2v3
!fl/**/ios/**/default.pbxuser
!fl/**/ios/**/default.perspectivev3
!fl/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
```